### PR TITLE
support for no cow option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,9 @@ Makefile
 _build/
 blib/
 pm_to_blib
-FileCheck.bs
-FileCheck.c
-FileCheck.o
+COW.bs
+COW.c
+COW.o
 .gdb_history
 Makefile.old
 MANIFEST.bak

--- a/COW.xs
+++ b/COW.xs
@@ -15,7 +15,7 @@
 
 #define MIN_PERL_VERSION_FOR_COW  20
 
-#if PERL_REVISION >= 5 && PERL_VERSION >= MIN_PERL_VERSION_FOR_COW  
+#if defined(SV_COW_REFCNT_MAX)
 #   define B_CAN_COW 1
 #else
 #   define B_CAN_COW 0

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -8,7 +8,7 @@ use Devel::Peek;
 
 use B::COW qw{:all};
 
-if ( $] >= 5.020 ) {
+if ( can_cow() ) {
     ok can_cow(), "can cow with Perl $]";    
 
     ok !is_cow(undef), "!is_cow(undef)";


### PR DESCRIPTION
Perl as recent as 5.30.2 can be configured without COW support via configure option `-Accflags='-DPERL_NO_COW'`.  I believe 5.18 can also be built with COW support turned on, however, I haven't tested that configuration.

This makes B::COW work on such configurations in the same way as it previously "worked" on Perl 5.18 and older.

 