### PR TITLE
Fix CowREFCNT logic using myCowREFCNT

### DIFF
--- a/COW.xs
+++ b/COW.xs
@@ -21,6 +21,9 @@
 #   define B_CAN_COW 0
 #endif
 
+/* CowREFCNT is incorrect on Perl < 5.32 */
+#define myCowREFCNT(sv)   ((SvLEN(sv)>0) ? CowREFCNT(sv) : 0)
+
 MODULE = B__COW       PACKAGE = B::COW
 
 SV*
@@ -60,7 +63,7 @@ CODE:
 #if !B_CAN_COW
     XSRETURN_UNDEF;
 #else
-    if ( SvIsCOW(sv) ) XSRETURN_IV( CowREFCNT(sv) );
+    if ( SvIsCOW(sv) ) XSRETURN_IV( myCowREFCNT(sv) );
 #endif
     XSRETURN_UNDEF;
 }

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -52,11 +52,10 @@ if ( can_cow() ) {
     }
 
     {
-        my %h = ( 'a'..'d' );
-        foreach my $k ( sort keys %h ) {
-            ok is_cow( $k ), "key $k is cowed";
-            is cowrefcnt( $k ), 0, "hash key $k cowrefcnt is 0" or Dump($k);
-        }
+        my %h = ( 'my_hash_key' => 'value' );
+        my @keys = keys %h;
+        ok is_cow( $keys[0] ), "hash key is cowed";
+        is cowrefcnt( $keys[0] ), 0, "hash key cowrefcnt is 0" or die Dump($keys[0]);
     }
 
 } else {


### PR DESCRIPTION
Fix #1

If the SvPV has a LEN=0, we should
not try to read what's in front to
access the CowREFCNT and consider its
value is 0.