### PR TITLE
explicitly disable prototypes to silence warning

### DIFF
--- a/COW.xs
+++ b/COW.xs
@@ -23,6 +23,8 @@
 
 MODULE = B__COW       PACKAGE = B::COW
 
+PROTOTYPES: DISABLE
+
 SV*
 can_cow()
 CODE:


### PR DESCRIPTION
By default, XS functions are not given prototypes in perl. But unless explicitly specified, this will produce a warning.

Explicitly declare that prototypes are disabled to silence this warning.